### PR TITLE
Segmentation fault removed

### DIFF
--- a/launch/test_client.launch
+++ b/launch/test_client.launch
@@ -1,0 +1,3 @@
+<launch>
+	<node pkg="behaviortree_ros" type="test_bt" name="test_bt" output="screen" />
+</launch>

--- a/launch/test_server.launch
+++ b/launch/test_server.launch
@@ -1,0 +1,3 @@
+<launch>
+	<node pkg="behaviortree_ros" type="test_server" name="test_server" output="screen" />
+</launch>

--- a/test/test_server.cpp
+++ b/test/test_server.cpp
@@ -45,15 +45,15 @@ public:
 
   void executeCB(const behaviortree_ros::FibonacciGoalConstPtr &goal)
   {
-    // publish info to the console for the user
-    ROS_INFO("%s: Executing, creating fibonacci sequence of order %i with seeds %i, %i",
-             action_name_.c_str(), goal->order, feedback_.sequence[0], feedback_.sequence[1]);
-
     // calculate the result
     // push_back the seeds for the fibonacci sequence
     feedback_.sequence.clear();
     feedback_.sequence.push_back(0);
     feedback_.sequence.push_back(1);
+    // publish info to the console for the user
+    ROS_INFO("%s: Executing, creating fibonacci sequence of order %i with seeds %i, %i",
+             action_name_.c_str(), goal->order, feedback_.sequence[0], feedback_.sequence[1]);
+             
     for(int i=1; i<=goal->order; i++)
     {
       feedback_.sequence.push_back(feedback_.sequence[i] + feedback_.sequence[i-1]);


### PR DESCRIPTION
Segmentation fault when running test_server.
ROS_INFO uses feedback_.sequence[0], feedback_.sequence[1] before they are set.