### PR TITLE
Implement different strategy to load server name

### DIFF
--- a/include/behaviortree_ros/bt_action_node.h
+++ b/include/behaviortree_ros/bt_action_node.h
@@ -33,7 +33,7 @@ namespace BT
  *  - onResult
  *  - onFailedRequest
  *  - halt (optionally)
- *
+ *  - getServerName (optionally)
  */
 template<class ActionT>
 class RosActionNode : public BT::ActionNodeBase
@@ -43,7 +43,7 @@ protected:
   RosActionNode(ros::NodeHandle& nh, const std::string& name, const BT::NodeConfiguration & conf):
   BT::ActionNodeBase(name, conf), node_(nh)
   {
-    const std::string server_name = getInput<std::string>("server_name").value();
+    const std::string server_name = getServerName();
     action_client_ = std::make_shared<ActionClientType>( node_, server_name, true );
   }
 
@@ -77,6 +77,13 @@ public:
   /// Method (to be implemented by the user) to receive the reply.
   /// User can decide which NodeStatus it will return (SUCCESS or FAILURE).
   virtual NodeStatus onResult( const ResultType& res) = 0;
+
+  /// Called to retrieve the action server name. Can be overriden by the user.
+  virtual std::string getServerName()
+  {
+    return getInput<std::string>("server_name").value();
+  }
+
 
   enum FailureCause{
     MISSING_SERVER = 0,

--- a/include/behaviortree_ros/bt_service_node.h
+++ b/include/behaviortree_ros/bt_service_node.h
@@ -63,6 +63,13 @@ public:
   /// User can decide which NodeStatus it will return (SUCCESS or FAILURE).
   virtual NodeStatus onResponse( const ResponseType& rep) = 0;
 
+  /// Called to retrieve the action server name. Can be overriden by the user.
+  virtual std::string getServiceName()
+  {
+    return getInput<std::string>("service_name").value();
+  }
+
+
   enum FailureCause{
     MISSING_SERVER = 0,
     FAILED_CALL = 1
@@ -86,7 +93,7 @@ protected:
   BT::NodeStatus tick() override
   {
     if( !service_client_.isValid() ){
-      std::string server = getInput<std::string>("service_name").value();
+      std::string server = getServiceName();
       service_client_ = node_.serviceClient<ServiceT>( server );
     }
 


### PR DESCRIPTION
In an application, that I am developing,  I need to hide the server names from the developers of the behaviour trees and therefore I did this very minor change to give to the user the possibility to override the default strategy to load the server names.

Maybe this could be useful even for others.