### PR TITLE
Update rosout_logger.cpp

### DIFF
--- a/src/loggers/rosout_logger.cpp
+++ b/src/loggers/rosout_logger.cpp
@@ -48,15 +48,15 @@ void RosoutLogger::callback(Duration timestamp, const TreeNode& node, NodeStatus
     case ros::console::Level::Debug :
         ROS_DEBUG("[%s%s]: %s -> %s",  node_name.c_str(),
                   &whitespaces[std::min(ws_count, node_name.size())],
-                  toStr(prev_status, true),
-                  toStr(status, true));
+                  toStr(prev_status, true).c_str(),
+                  toStr(status, true).c_str());
         break;
 
     case ros::console::Level::Info :
         ROS_INFO("[%s%s]: %s -> %s",  node_name.c_str(),
                   &whitespaces[std::min(ws_count, node_name.size())],
-                  toStr(prev_status, true),
-                  toStr(status, true));
+                  toStr(prev_status, true).c_str(),
+                  toStr(status, true).c_srt());
         break;
     }
 }


### PR DESCRIPTION
Correct me if I'm wrong, but I think this will fix the output string when the encoding was broken in a number of cases.

#### Before:  

![image](https://user-images.githubusercontent.com/47717531/113063085-612b3480-91bd-11eb-9381-200f45eb782b.png)   

#### After:  

![image](https://user-images.githubusercontent.com/47717531/113063254-ad767480-91bd-11eb-9825-0119ba7a8f4f.png)  
