### PR TITLE
Allow to set server_name/service_name in RegisterRosAction/RegisterRosService

### DIFF
--- a/include/behaviortree_ros/bt_action_node.h
+++ b/include/behaviortree_ros/bt_action_node.h
@@ -40,11 +40,11 @@ class RosActionNode : public BT::ActionNodeBase
 {
 protected:
 
-  RosActionNode(ros::NodeHandle& nh, const std::string& name, const BT::NodeConfiguration & conf):
+  RosActionNode(ros::NodeHandle& nh, const std::string& name, const BT::NodeConfiguration & conf, const std::string& server_name):
   BT::ActionNodeBase(name, conf), node_(nh)
   {
-    const std::string server_name = getInput<std::string>("server_name").value();
-    action_client_ = std::make_shared<ActionClientType>( node_, server_name, true );
+    const std::string server_name_ = server_name.empty() ? getInput<std::string>("server_name").value() : server_name;
+    action_client_ = std::make_shared<ActionClientType>( node_, server_name_, true );
   }
 
 public:
@@ -172,7 +172,7 @@ template <class DerivedT> static
                          ros::NodeHandle& node_handle)
 {
   NodeBuilder builder = [&node_handle](const std::string& name, const NodeConfiguration& config) {
-    return std::make_unique<DerivedT>(node_handle, name, config );
+    return std::make_unique<DerivedT>(node_handle, name, config, "" );
   };
 
   TreeNodeManifest manifest;

--- a/include/behaviortree_ros/bt_action_node.h
+++ b/include/behaviortree_ros/bt_action_node.h
@@ -169,10 +169,11 @@ protected:
 template <class DerivedT> static
   void RegisterRosAction(BT::BehaviorTreeFactory& factory,
                          const std::string& registration_ID,
-                         ros::NodeHandle& node_handle)
+                         ros::NodeHandle& node_handle,
+                         const std::string& server_name)
 {
-  NodeBuilder builder = [&node_handle](const std::string& name, const NodeConfiguration& config) {
-    return std::make_unique<DerivedT>(node_handle, name, config, "" );
+  NodeBuilder builder = [&node_handle, &server_name](const std::string& name, const NodeConfiguration& config) {
+    return std::make_unique<DerivedT>(node_handle, name, config, server_name );
   };
 
   TreeNodeManifest manifest;

--- a/test/test_bt.cpp
+++ b/test/test_bt.cpp
@@ -187,7 +187,7 @@ int main(int argc, char **argv)
 
   factory.registerNodeType<PrintValue>("PrintValue");
   RegisterRosService<AddTwoIntsAction>(factory, "AddTwoInts", nh);
-  RegisterRosAction<FibonacciServer>(factory, "Fibonacci", nh);
+  RegisterRosAction<FibonacciServer>(factory, "Fibonacci", nh, "");
 
   auto tree = factory.createTreeFromText(xml_text);
 

--- a/test/test_bt.cpp
+++ b/test/test_bt.cpp
@@ -94,8 +94,8 @@ class FibonacciServer: public RosActionNode<behaviortree_ros::FibonacciAction>
 {
 
 public:
-  FibonacciServer( ros::NodeHandle& handle, const std::string& name, const NodeConfiguration & conf):
-RosActionNode<behaviortree_ros::FibonacciAction>(handle, name, conf) {}
+  FibonacciServer( ros::NodeHandle& handle, const std::string& name, const NodeConfiguration & conf, const std::string& server_name):
+RosActionNode<behaviortree_ros::FibonacciAction>(handle, name, conf, server_name) {}
 
   static PortsList providedPorts()
   {


### PR DESCRIPTION
Referring to Issue #15

Open points:
- [ ]  Current version is compiling but throws a runtime error. Make the changes work
- [ ]  Throw error if neither port nor input is non-empty
- [ ]  Make input optional?