### PR TITLE
Install header files to be available in install-space

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,8 @@ target_link_libraries(test_server ${catkin_LIBRARIES} )
 ######################################################
 # INSTALL
 
+install(DIRECTORY include/${PROJECT_NAME}/
+        DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
 
 ######################################################
 # EXAMPLES and TOOLS


### PR DESCRIPTION
Thx for the nice wrappers.

We noticed that when building this in install-space, the headers are not available. This PR fixes that.
